### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,7 @@ Imports:
   Rcpp,
   RcppParallel,
   rlang,
-  rstan,
+  rstan (>= 2.26.0),
   rstantools,
   stats,
   tibble,
@@ -71,6 +71,6 @@ LinkingTo:
   Rcpp,
   RcppEigen,
   RcppParallel,
-  rstan,
-  StanHeaders
+  rstan (>= 2.26.0),
+  StanHeaders (>= 2.26.0)
 SystemRequirements: GNU make

--- a/inst/stan/historicalborrowlong.stan
+++ b/inst/stan/historicalborrowlong.stan
@@ -70,9 +70,9 @@ data {
   int<lower=0> n_lambda_historical;
   int<lower=0> n_rho_current;
   int<lower=0> n_rho_historical;
-  int<lower=0> n_patient_study[n_study];
-  int<lower=0> index_patient_study[n_study];
-  int<lower=0> index_patient[n_observe];
+  array[n_study] int<lower=0> n_patient_study;
+  array[n_study] int<lower=0> index_patient_study;
+  array[n_observe] int<lower=0> index_patient;
   real<lower=0> s_alpha;
   real<lower=0> s_mu;
   real<lower=0> s_tau;
@@ -80,17 +80,17 @@ data {
   real<lower=0> s_delta;
   real<lower=0> s_sigma;
   real<lower=0> s_lambda;
-  int<lower=0> missing[n_observe];
-  int<lower=0> count_missing[n_observe];
-  int<lower=0> study_index[n_observe];
-  int<lower=0> alpha_rep_index[n_alpha];
-  int<lower=0> alpha_data_index[n_observe];
-  int<lower=0> delta_data_index[n_observe];
-  int<lower=0> x_beta_col_index[n_study_x_beta];
-  int<lower=0> x_beta_row_index[n_study_x_beta];
-  int<lower=0> x_beta_col_n[n_study_x_beta];
-  int<lower=0> x_beta_row_n[n_study_x_beta];
-  int<lower=0,upper=n_patient> study_patient[n_patient];
+  array[n_observe] int<lower=0> missing;
+  array[n_observe] int<lower=0> count_missing;
+  array[n_observe] int<lower=0> study_index;
+  array[n_alpha] int<lower=0> alpha_rep_index;
+  array[n_observe] int<lower=0> alpha_data_index;
+  array[n_observe] int<lower=0> delta_data_index;
+  array[n_study_x_beta] int<lower=0> x_beta_col_index;
+  array[n_study_x_beta] int<lower=0> x_beta_row_index;
+  array[n_study_x_beta] int<lower=0> x_beta_col_n;
+  array[n_study_x_beta] int<lower=0> x_beta_row_n;
+  array[n_patient] int<lower=0,upper=n_patient> study_patient;
   vector[n_observe] y;
   matrix[n_observe, n_alpha] x_alpha;
   matrix[n_observe, n_delta] x_delta;
@@ -108,16 +108,16 @@ parameters {
   vector<lower=0,upper=s_tau>[n_tau] tau;
   vector[n_delta] delta;
   vector[n_beta] beta;
-  vector<lower=0,upper=s_sigma>[n_rep] sigma[n_study];
-  cholesky_factor_corr[n_rep] lambda_current[n_lambda_current];
-  cholesky_factor_corr[n_rep] lambda_historical[n_lambda_historical];
+  array[n_study] vector<lower=0,upper=s_sigma>[n_rep] sigma;
+  array[n_lambda_current] cholesky_factor_corr[n_rep] lambda_current;
+  array[n_lambda_historical] cholesky_factor_corr[n_rep] lambda_historical;
   vector<lower=-1,upper=1>[n_rho_current] rho_current;
   vector<lower=-1,upper=1>[n_rho_historical] rho_historical;
 }
 transformed parameters {
   vector[n_alpha] alpha;
   matrix[n_rep, n_patient] epsilon;
-  matrix[n_rep, n_rep] covariance_cholesky[n_study];
+  array[n_study] matrix[n_rep, n_rep] covariance_cholesky;
   {
     int index;
     int last_visit;


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
